### PR TITLE
Use PascalCase for component registration

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -158,6 +158,6 @@ class ReCaptcha {
 }
 
 export default function (_, inject) {
-  Vue.component('recaptcha', () => import('./recaptcha.vue'))
+  Vue.component('Recaptcha', () => import('./recaptcha.vue'))
   inject('recaptcha', new ReCaptcha(<%= serialize(options) %>))
 }


### PR DESCRIPTION
This allows both `<Recaptcha>` and `<recaptcha>` to be used in templates.

Components that are registered in PascalCase can be used in templates with either PascalCase or kebab-case, whereas components registered in kebab-case can only be referenced in kebab-case. Some projects prefer to use PascalCase for component tags, so it's better for this plugin to make both options available.

See https://vuejs.org/v2/guide/components-registration.html#Name-Casing