### PR TITLE
Get siteKey from env variable

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -5,7 +5,7 @@ const { resolve } = require('path')
 module.exports = function (moduleOptions) {
   const options = {
     ...moduleOptions,
-    ...this.options.recaptcha,
+    ...this.options.recaptcha
   }
 
   const siteKeyEnv = options.siteKeyEnvVariable || 'RECAPTCHA_KEY'

--- a/lib/module.js
+++ b/lib/module.js
@@ -5,13 +5,14 @@ const { resolve } = require('path')
 module.exports = function (moduleOptions) {
   const options = {
     ...moduleOptions,
-    ...this.options.recaptcha
+    ...this.options.recaptcha,
   }
+
+  const siteKeyEnv = options.siteKeyEnvVariable || 'RECAPTCHA_KEY'
 
   this.addPlugin({
     fileName: 'recaptcha.js',
-    options,
-
+    options: { ...options, siteKey: options.siteKey || process.env[siteKeyEnv] },
     src: resolve(__dirname, 'plugin.js')
   })
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,7 +4,7 @@ import Vue from 'vue'
 const API_URL = 'https://www.google.com/recaptcha/api.js'
 
 class ReCaptcha {
-  constructor ({ hideBadge, language, siteKey, siteKeyEnvVariable = 'RECAPTCHA_KEY', version, size }) {
+  constructor ({ hideBadge, language, siteKey, version, size }) {
     if (!siteKey) {
       throw new Error('ReCaptcha error: No key provided')
     }
@@ -21,7 +21,7 @@ class ReCaptcha {
     this.hideBadge = hideBadge
     this.language = language || 'en'
 
-    this.siteKey = siteKey || process.env[siteKeyEnvVariable]
+    this.siteKey = siteKey
     this.version = version
     this.size = size
   }

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -4,7 +4,7 @@ import Vue from 'vue'
 const API_URL = 'https://www.google.com/recaptcha/api.js'
 
 class ReCaptcha {
-  constructor ({ hideBadge, language, siteKey, version, size }) {
+  constructor ({ hideBadge, language, siteKey, siteKeyEnvVariable = 'RECAPTCHA_KEY', version, size }) {
     if (!siteKey) {
       throw new Error('ReCaptcha error: No key provided')
     }
@@ -21,7 +21,7 @@ class ReCaptcha {
     this.hideBadge = hideBadge
     this.language = language || 'en'
 
-    this.siteKey = siteKey
+    this.siteKey = siteKey || process.env[siteKeyEnvVariable]
     this.version = version
     this.size = size
   }


### PR DESCRIPTION
It's common practice to store API keys in environment variables so they aren't versioned. This PR fallbacks to an env variable when siteKey is not explicitly set.