### PR TITLE
Make script init error catchable

### DIFF
--- a/example/v3/pages/index.vue
+++ b/example/v3/pages/index.vue
@@ -30,7 +30,11 @@ export default {
   }),
 
   async mounted() {
-    await this.$recaptcha.init()
+    try {
+      await this.$recaptcha.init()
+    } catch (e) {
+      console.log(e);
+    }
   },
 
   methods: {

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -107,11 +107,6 @@ class ReCaptcha {
 
     const { script, style } = this._elements
 
-    script.addEventListener('error', () => {
-      document.head.removeChild(script)
-      throw new Error('ReCaptcha error: Failed to load script')
-    })
-
     script.setAttribute('async', '')
     script.setAttribute('defer', '')
 
@@ -121,13 +116,11 @@ class ReCaptcha {
       script.setAttribute('src', API_URL + '?render=' + this.siteKey)
     }
 
-    document.head.appendChild(script)
-
     window.recaptchaSuccessCallback = (token) => this._eventBus.emit('recaptcha-success', token)
     window.recaptchaExpiredCallback = () => this._eventBus.emit('recaptcha-expired')
     window.recaptchaErrorCallback = () => this._eventBus.emit('recaptcha-error', 'Failed to execute')
 
-    this._ready = new Promise(resolve => {
+    this._ready = new Promise((resolve, reject) => {
       script.addEventListener('load', () => {
         if (this.version === 3 && this.hideBadge) {
           style.innerHTML = '.grecaptcha-badge { display: none }'
@@ -141,6 +134,13 @@ class ReCaptcha {
 
         window.grecaptcha.ready(resolve)
       })
+
+      script.addEventListener('error', () => {
+        document.head.removeChild(script)
+        reject('ReCaptcha error: Failed to load script')
+      })
+
+      document.head.appendChild(script)
     })
 
     return this._ready

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -138,6 +138,7 @@ class ReCaptcha {
       script.addEventListener('error', () => {
         document.head.removeChild(script)
         reject('ReCaptcha error: Failed to load script')
+        this._ready = null;
       })
 
       document.head.appendChild(script)


### PR DESCRIPTION
Currently if the Recaptcha scripts fails to load (network failure, etc) an exception is thrown. However, because it is thrown inside an event callback it cannot be caught further up the stack. This pull request moves the callback to within the `_ready` promise where it can be rejected if the error callback is triggered. This can then easily be caught and an error displayed to the user.