### PR TITLE
feat(multi-widget): render and verify multiple v2 widgets

### DIFF
--- a/example/both/nuxt.config.js
+++ b/example/both/nuxt.config.js
@@ -1,0 +1,19 @@
+const { resolve } = require('path')
+
+module.exports = {
+  buildDir: resolve(__dirname, '.nuxt'),
+
+  modules: [
+    ['../../lib/module', {
+      hideBadge: true,
+      siteKey: '6LeE3ZAUAAAAANVaDO60w4ZBK44khqO7OpsitZNY',
+
+      version: 3,
+    }]
+  ],
+
+  srcDir: __dirname,
+
+  render: { resourceHints: false },
+  rootDir: resolve(__dirname, '..')
+}

--- a/example/both/pages/index.vue
+++ b/example/both/pages/index.vue
@@ -1,0 +1,62 @@
+<template>
+  <section class="index-page">
+    <h2>Sign In</h2>
+
+    <form @submit.prevent="onSubmit">
+      <input
+        v-model="email"
+        autocomplete="true"
+        placeholder="Email"
+        type="email"
+      >
+
+      <input
+        v-model="password"
+        autocomplete="current-password"
+        placeholder="Password"
+        type="password"
+      >
+      <recaptcha
+        id="v2-normal"
+        site-key="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"
+      />
+      <button type="submit">
+        Sign In
+      </button>
+    </form>
+  </section>
+</template>
+
+<script>
+export default {
+  data: () => ({
+    email: 'test@example.com',
+    password: '123',
+    widgetId: 0
+  }),
+
+  async mounted() {
+    await this.$recaptcha.init()
+
+    this.widgetId = this.$recaptcha.render('v2-normal', {
+      sitekey: '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI'
+    })
+  },
+
+  methods: {
+    async onSubmit() {
+      try {
+        const tokenV2 = await this.$recaptcha.getResponse(this.widgetId)
+        console.log('V2 ReCaptcha token:', tokenV2)
+
+        const token = await this.$recaptcha.execute('login')
+        console.log('V3 ReCaptcha token:', token)
+
+        this.$recaptcha.reset(this.widgetId)
+      } catch (error) {
+        console.log('Login error:', error)
+      }
+    }
+  }
+}
+</script>

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -61,11 +61,11 @@ class ReCaptcha {
     }
   }
 
-  getResponse () {
+  getResponse (widgetId) {
     return new Promise((resolve, reject) => {
       if ('grecaptcha' in window) {
         if(this.size == 'invisible'){
-          window.grecaptcha.execute()
+          window.grecaptcha.execute(widgetId)
 
           window.recaptchaSuccessCallback = token => {
             this._eventBus.emit('recaptcha-success', token)
@@ -77,7 +77,7 @@ class ReCaptcha {
             reject(error)
           }
         } else {
-          const response = window.grecaptcha.getResponse()
+          const response = window.grecaptcha.getResponse(widgetId)
 
           if (response) {
             this._eventBus.emit('recaptcha-success', response)
@@ -96,7 +96,7 @@ class ReCaptcha {
 
   init () {
     if (this._ready) {
-      return Promise.resolve()
+      return this._ready
     }
 
     this._eventBus = new EventEmitter()
@@ -151,10 +151,14 @@ class ReCaptcha {
     return this._eventBus.on(event, callback)
   }
 
-  reset () {
+  reset (widgetId) {
     if (this.version === 2) {
-      window.grecaptcha.reset()
+      window.grecaptcha.reset(widgetId)
     }
+  }
+
+  render (reference, { sitekey, theme }) {
+    return window.grecaptcha.render(reference.$el || reference, { sitekey, theme })
   }
 }
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -96,6 +96,7 @@ class ReCaptcha {
 
   init () {
     if (this._ready) {
+      // make sure caller waits until recaptcha get ready
       return this._ready
     }
 

--- a/lib/recaptcha.vue
+++ b/lib/recaptcha.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    :data-sitekey="$recaptcha.siteKey"
+    :data-sitekey="siteKey || $recaptcha.siteKey"
     :data-size="$recaptcha.size || dataSize"
     :data-theme="dataTheme"
     :data-badge="dataBadge"
@@ -15,38 +15,17 @@
 
 <script>
 export default {
-  beforeDestroy () {
-    this.$recaptcha.destroy()
-  },
-
-  methods: {
-    onError (message) {
-      return this.$emit('error', message)
-    },
-
-    onSuccess (token) {
-      return this.$emit('success', token)
-    },
-
-    onExpired () {
-      return this.$emit('expired')
-    }
-  },
-
-  mounted () {
-    this.$recaptcha.init()
-
-    this.$recaptcha.on('recaptcha-error', this.onError)
-    this.$recaptcha.on('recaptcha-success', this.onSuccess)
-    this.$recaptcha.on('recaptcha-expired', this.onExpired)
-  },
-
   props: {
+    siteKey: {
+      type: String,
+      default: ''
+    },
+
     dataTheme: {
       default: 'light',
       type: String,
 
-      validator: value => {
+      validator: (value) => {
         return ['dark', 'light'].includes(value)
       }
     },
@@ -55,23 +34,48 @@ export default {
       default: 'normal',
       type: String,
 
-      validator: value => {
+      validator: (value) => {
         return ['compact', 'normal', 'invisible'].includes(value)
       }
     },
-    
+
     dataBadge: {
       default: 'bottomright',
       type: String,
-      
-      validator: value => {
+
+      validator: (value) => {
         return ['bottomright', 'bottomleft', 'inline'].includes(value)
       }
     },
-    
+
     dataTabindex: {
       default: 0,
       type: Number
+    }
+  },
+  beforeDestroy() {
+    this.$recaptcha.destroy()
+  },
+
+  mounted() {
+    this.$recaptcha.init()
+
+    this.$recaptcha.on('recaptcha-error', this.onError)
+    this.$recaptcha.on('recaptcha-success', this.onSuccess)
+    this.$recaptcha.on('recaptcha-expired', this.onExpired)
+  },
+
+  methods: {
+    onError(message) {
+      return this.$emit('error', message)
+    },
+
+    onSuccess(token) {
+      return this.$emit('success', token)
+    },
+
+    onExpired() {
+      return this.$emit('expired')
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "access": "public"
   },
   "scripts": {
+    "dev": "nuxt example/both",
     "dev:v3": "nuxt example/v3",
     "dev:v2": "nuxt example/v2",
     "lint": "eslint lib test",


### PR DESCRIPTION
- [X] Ability to render `v2` widgets while using `v3` api. As the official docs says: [Can I run reCAPTCHA v2 and v3 on the same page?](https://developers.google.com/recaptcha/docs/faq#can-i-run-recaptcha-v2-and-v3-on-the-same-page)

- [X] Add support for `reset` and `getResponse` of specific widget using widgetId.

resolves #61, resolves #68