### PR TITLE
fix: remove badge on destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ async onSubmit() {
 }
 ```
 
+3. Call `destroy` function inside `beforeDestroy` hook of the page. (This will remove reCAPTCHA scripts, styles and badge from the page)
+
+```js
+beforeDestroy() {
+  this.$recaptcha.destroy()
+}
+```
+
 See: [v3 example](https://github.com/nuxt-community/recaptcha-module/tree/master/example/v3)
 
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -43,6 +43,11 @@ class ReCaptcha {
       if (head.contains(style)) {
         head.removeChild(style)
       }
+      
+      const badge = document.querySelector('.grecaptcha-badge')
+      if (badge) {
+        badge.remove()
+      }
     }
   }
 


### PR DESCRIPTION
Remove recaptcha badge on calling `$recaptcha.destory`

resolves #6 