### PR TITLE
fix: reset for multi-widget

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -161,7 +161,7 @@ class ReCaptcha {
   }
 
   reset (widgetId) {
-    if (this.version === 2) {
+    if (this.version === 2 || typeof widgetId !== 'undefined') {
       window.grecaptcha.reset(widgetId)
     }
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -47,7 +47,12 @@ export interface ReCaptchaInstance {
   /**
    * Reset ReCaptcha (v2)
    */
-  reset(): void
+  reset(widgetId?: number): void
+
+  /**
+   * Render ReCaptcha (v2)
+   */
+  render(reference: string, { siteKey, theme } : { siteKey: string, theme?: string }): number
 }
 
 declare module 'vue/types/vue' {


### PR DESCRIPTION
Issue: `reset()` is not working for multi-widget as `this.version` is 3 and `this.version === 2` condition in `reset()` returns false
Fix: Implemented extra condition in `reset()` to handle multi-widget.