### PR TITLE
fix: prioritized dynamic input vs config

### DIFF
--- a/lib/recaptcha.vue
+++ b/lib/recaptcha.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :data-sitekey="siteKey || $recaptcha.siteKey"
-    :data-size="$recaptcha.size || dataSize"
+    :data-size="dataSize || $recaptcha.size"
     :data-theme="dataTheme"
     :data-badge="dataBadge"
     :data-tabindex="dataTabindex"


### PR DESCRIPTION
In the dev environment of this library, the `dataSize` can be overridden manually because the instance is being created via the module, not while bootstrapping, like in a real-life application.

Due to project requirements, I must use v2 and have multiple key types, thus I must be able to override multiple keys throught the project.

My current workaround is before calling `getResponse()` I set the size in the object:

```javascript
this.$recaptcha.size = 'invisible';
const token = await this.$recaptcha.getResponse();

```

Here is a quick fix for this, if you could review it ASAP it would be great as my team is on a time crunch.

Thanks,
Andrew