### PR TITLE
feat: included description for "success, expires and error" emitted event in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ async onSubmit() {
 ```
 See: [v2 example](https://github.com/nuxt-community/recaptcha-module/tree/master/example/v2)
 
+
+
 ### reCAPTCHA v3
 
 1. Call `init` function inside `mounted` hook of your page
@@ -145,6 +147,38 @@ beforeDestroy() {
 ```
 
 See: [v3 example](https://github.com/nuxt-community/recaptcha-module/tree/master/example/v3)
+
+### Handling success, expire and error Events on Recaptcha component 
+
+in your vue component where the `<recapcha />` is included you can bind events ` @success, @expires and @error ` to trigger  when the recaptcha is either validate successfully, timedout or triggers an error. Hence, 
+
+```vue
+<form @submit.prevent="onSubmit">
+  <input autocomplete="true" placeholder="Email" type="email" v-model="email">
+  <input autocomplete="current-password" placeholder="Password" type="password" v-model="password">
+  <recaptcha @success="onSuccess" @expired="onExpires" @error="onError" />
+  <button type="submit">Sign In</button>
+</form>
+```
+
+in your vue script inside the methods
+```js
+async onSuccess(token){
+  console.log("recaptcha validates successfully with token")
+}
+
+async onExpires(){
+  console.log("recaptcha validation expires")
+}
+
+async onError(message){
+  console.log("recaptcha error with message " + message)
+}
+```
+
+note: the onExpires method does not take any parameter
+
+See: [v2 example](https://github.com/nuxt-community/recaptcha-module/blob/master/example/v2/pages/index.vue)
 
 
 ### Server Side


### PR DESCRIPTION
The doc does not contain guide on handling the three events (success, expires  and error) emitted in the recaptcha.vue component.
Hence, adding the guide in the readme.md will reduce the hustle of going through google or the codebase to find out how to do so

