### PR TITLE
[Types] Add missing optional properties to ReCaptchaOptions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,11 @@ export interface ReCaptchaOptions {
   hideBadge?: boolean
 
   /**
+   * ReCaptcha language (v2)
+   */
+  language?: string
+
+  /**
    * ReCaptcha mode.
    */
   mode?: 'base' | 'enterprise'
@@ -15,6 +20,11 @@ export interface ReCaptchaOptions {
    * Site key to send requests
    */
   siteKey: string
+
+  /**
+   * Size of the widget (v2)
+   */
+  size?: 'compact' | 'normal' | 'invisible'
 
   /**
    * Version


### PR DESCRIPTION
#### 🔍 Context
Closes #120 - `ReCaptchaOptions` interface lacks 2 properties needed for v2 (`language` and `size`)
#### 🏗 Work
- [x] Update `./types/index.d.ts`