### PR TITLE
correct type definitions of settings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-export interface ReCaptchaOptions {
+export interface ReCaptchaInstance {
   /**
    * Toggles badge element visibility (v3)
    */
@@ -30,13 +30,6 @@ export interface ReCaptchaOptions {
    * Version
    */
   version: number
-}
-
-export interface ReCaptchaInstance {
-  /**
-   * Options
-   */
-  options: ReCaptchaOptions
 
   /**
    * Destroy ReCaptcha


### PR DESCRIPTION
To verify, open a Nuxt page where recaptcha is loaded and type `$nuxt.$recaptcha.options` into the console or try to read e.g. the site key in the code using `this.$recaptcha.options.siteKey` which results in an error. Instead, the site key (along with all other options) can be found at the parent level: `this.$recaptcha.siteKey`.